### PR TITLE
Retouching top page&item show sever side

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,12 +2,12 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:myitem, :show, :destroy]
 
   def index
-    @ladys_items = Item.where(category_id: 1)
+    @ladys_items = Item.where(category_id: 1).order('id ASC').limit(10)
   end
 
   def show
-    @user_items = Item.where(user_id: "#{@item.user.id}")
-    @brand_items = Item.where(brand_id: "#{@item.brand.id}")
+    @user_items = Item.where(user_id: "#{@item.user.id}").order('id ASC').limit(6).where.not(id: @item.id)
+    @brand_items = Item.where(brand_id: "#{@item.brand.id}").order('id ASC').limit(6).where.not(id: @item.id)
   end
 
   def destroy

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -23,11 +23,11 @@
           もっと見る
           =fa_icon"chevron-right",class:'icon'
       .new-arrival-item
-        - @ladys_items.each_with_index do |item, i|
+        - @ladys_items.each do |item|
           .new-arrival-item__box
             = link_to  item_path(item)  do
-              - item.item_images.each_with_index do |item_image, n|
-                - if n == 0
+              - item.item_images.each_with_index do |item_image, i|
+                - if i == 0
                   = image_tag item_image.image, alt: 'item-image', class: 'new-arrival-item__box--image'
                 - else
                   - break
@@ -36,8 +36,6 @@
               .new-arrival-item__box--price
                 ¥
                 = item.price
-          - if i == 9
-            - break
 
     .popular-brands 
       %h2.popular-brands__title

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -151,56 +151,47 @@
       = @item.user.nickname
       さんのその他の出品
 .item__buyer-collection 
-  - @user_items.each_with_index do |item, i|
-    - if item.id  == @item.id
-    - else
-      .item-show__item-box
-        = link_to  item_path(item)  do
-          - item.item_images.each_with_index do |item_image, n|
-            - if n == 0
-              = image_tag item_image.image, alt: 'item-image', class: 'recommnd-item__image'
-            - else
-              - break
-          .item-show__item-box-text
-            %span.item-show__item-box__title 
-              = item.name
-            .item-box-text__fee-box
-              %span.item-box-text__fee-box__fee
-                ¥
-                = item.price
-              .item-box-text__fee-box__right
-                = fa_icon 'heart-o', class: "icon"
-                %span  1
-      - if i == 6
-        - break
-        
+  - @user_items.each do |item|
+    .item-show__item-box
+      = link_to  item_path(item)  do
+        - item.item_images.each_with_index do |item_image, i|
+          - if i == 0
+            = image_tag item_image.image, alt: 'item-image', class: 'recommnd-item__image'
+          - else
+            - break
+        .item-show__item-box-text
+          %span.item-show__item-box__title 
+            = item.name
+          .item-box-text__fee-box
+            %span.item-box-text__fee-box__fee
+              ¥
+              = item.price
+            .item-box-text__fee-box__right
+              = fa_icon 'heart-o', class: "icon"
+              %span  1
+      
 .item__buyer-collection-title
   = link_to  "https://www.mercari.com/jp/safe/description/"  do
     %h2
       = @item.brand.name
       その他の商品
 .item__brand-collection
-  - @brand_items.each_with_index do |item, i|
-    - if item.id  == @item.id
-    - else
-      .item-show__item-box
-        = link_to  item_path(item)  do
-          - item.item_images.each_with_index do |item_image, n|
-            - if n == 0
-              = image_tag item_image.image, alt: 'item-image', class: 'recommnd-item__image'
-            - else
-              - break
-          .item-show__item-box-text
-            %span.item-show__item-box__title 
-              = item.name
-            .item-box-text__fee-box
-              %span.item-box-text__fee-box__fee
-                ¥
-                = item.price
-              .item-box-text__fee-box__right
-                = fa_icon 'heart-o', class: "icon"
-                %span  1
-      - if i == 6
-        - break
-        
+  - @brand_items.each do |item|
+    .item-show__item-box
+      = link_to  item_path(item)  do
+        - item.item_images.each_with_index do |item_image, i|
+          - if i == 0
+            = image_tag item_image.image, alt: 'item-image', class: 'recommnd-item__image'
+          - else
+            - break
+        .item-show__item-box-text
+          %span.item-show__item-box__title 
+            = item.name
+          .item-box-text__fee-box
+            %span.item-box-text__fee-box__fee
+              ¥
+              = item.price
+            .item-box-text__fee-box__right
+              = fa_icon 'heart-o', class: "icon"
+              %span  1
 = render partial: 'shared/footer'


### PR DESCRIPTION
# what
トップページと商品詳細画面のサーバーサイドの修正。

「変更点」
・コントローラー@user_items = Item.where(user_id: "#{@item.user.id}")の記述に
　.order('id ASC').limit(6).where.not(id: @item.id)を加え、
　取り出すアイテム数を指定

・ビューのeach_wiith_indexをeachに変更し
　アイテム数により表示を変えるif文を削除。


# before

[![Image from Gyazo](https://i.gyazo.com/0bbecc5c1deeb14c31dc43d478cfbb2a.gif)](https://gyazo.com/0bbecc5c1deeb14c31dc43d478cfbb2a)

# after

[![Image from Gyazo](https://i.gyazo.com/40b276ad91cd4e96eef2860268dcb29f.gif)](https://gyazo.com/40b276ad91cd4e96eef2860268dcb29f)