### PR TITLE
Detail editing view

### DIFF
--- a/app/assets/stylesheets/item_buy.scss
+++ b/app/assets/stylesheets/item_buy.scss
@@ -1,7 +1,7 @@
 
 .item-buy{
   width: 100vw;
-  height: 100vh;
+  height: 100%;
   margin: 0;
   padding: 0;
   
@@ -123,8 +123,8 @@
     }
 
     &__button{
-      border: 1px solid #888;
-      background: #888;
+      border: 1px solid #ea352d;;
+      background:#ea352d;
       color: #fff;
       width: 100%;
 

--- a/app/assets/stylesheets/shared/user_detail_index.scss
+++ b/app/assets/stylesheets/shared/user_detail_index.scss
@@ -1,9 +1,9 @@
 .identification-content{
   background-color: rgb(245, 245, 245);
-  height: 1500px;
-  padding: 0;
+  height: 100%;
+  padding: 0 0 50px 0;
   .identification-box{
-    height: 2000px;
+    height: 100%;
     width:  1020px;
     margin: 40px auto ;
   }

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -13,7 +13,7 @@
       .footer__up__inner
         .footer__up__inner__left
           .footer__up__inner__left__up スマホでかんたんフリマアプリ
-          .footer__up__inner__left__down 今すぐ無料ダウウンロード！
+          .footer__up__inner__left__down 今すぐ無料ダウンロード！
           .footer__up__inner__left__image
             = image_tag 'mercari_icon-f75780e32e41e052c8aaa8b446331cd8.png', class: 'footer__up__inner__left__image__mercari__icon'
             = link_to "https://apps.apple.com/jp/app/id667861049?l=ja", class: "camera__link", method: :get do

--- a/app/views/user_details/index.html.haml
+++ b/app/views/user_details/index.html.haml
@@ -1,6 +1,6 @@
 = render partial: 'shared/header'
 .identification-content
-  .identification-box
+  .identification-box.clearfix
     .identification-main
       %h2.identification-main__title
         本人情報の確認


### PR DESCRIPTION
# WHAT 
１、footerの誤字「ダウウンロード」→「ダウンロード」に変更
２、本人確認ページの下部とフッターの距離が長かった為編集
３、購入内容確認ページの”購入ボタン”をグレーから赤色に変更


１・３、https://gyazo.com/9dee23ccc5bb65f217a2800b48315370
２、https://gyazo.com/1fca97ad253912d632cab2591a7b0dc0
