### PR TITLE
search.html.haml編集　画像がない場合の表示実装

### DIFF
--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -15,9 +15,14 @@
             .search-item__index__content
               .search_item__image
                 = link_to  item_path(item)  do
-                  - item.item_images.each_with_index do |item_image,i|
-                    - if i == 0
-                      =image_tag item_image.image.url, width:"160",height:"170"
+                  -if item.item_images.present?
+                    - item.item_images.each_with_index do |item_image,i|
+                      - if i == 0
+                        =image_tag item_image.image.url, width:"160",height:"170"
+                      - else
+                        - break
+                  - else
+                    =image_tag 'no-image.png',class: 'search-items__image', width:"160",height:"170"
               .search-item__index__text
                 =item.name
               .item-price


### PR DESCRIPTION
# WHAT
検索一覧の中で、商品画像がない場合は[no image]を表示

# WHY
画像がない場合、画像部分が空欄になってしまう
画像がなくても空欄にさせないように、[no image]画像を表示

https://gyazo.com/771474b21fc404f2589e4fa5627ec7b0