### PR TITLE
Retouching top page server

### DIFF
--- a/app/assets/stylesheets/items_new.scss
+++ b/app/assets/stylesheets/items_new.scss
@@ -14,7 +14,14 @@
     text-align: center;
   }
 }
-
+.item-form__errors{
+  padding:12px;
+  font-weight:850;
+  color:#262626;
+  background:#FFEBE8;
+  border:2px solid #990000;
+  text-align: center;
+}
 .sell{
   &__form{
     border-top: 1px solid #eee;

--- a/app/assets/stylesheets/signup.scss
+++ b/app/assets/stylesheets/signup.scss
@@ -79,6 +79,7 @@
   border: #979797 solid 1px !important;
   &__text{
     margin: 0 auto;
+    margin-right: 110px;
   }
 }
 .signup__body__footer{

--- a/app/assets/stylesheets/signup.scss
+++ b/app/assets/stylesheets/signup.scss
@@ -43,8 +43,10 @@
   color: #fff;
   background-color: #ea352d;
   &__logo{
-    margin-left: 16px;
-
+    margin-left: 10px;
+    i{
+      font-size: 24px;
+    }
   }
   &__text{
     color: #fff;
@@ -56,10 +58,17 @@
   background: #385185;
   color: #fff;
   &__logo{
-    margin-left: 16px;
+    margin-left: 10px;
+    position: relative;
   }
   &__text{
     margin: 0 auto;
+  }
+  i{
+    &::before{
+      position: absolute;
+      top: 20%;
+    }
   }
 }
 .google__choice{

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -56,7 +56,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path
     else
-      render :new
+      redirect_to new_item_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,9 +3,64 @@ class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index,:show]
   before_action :user_id_check, only: [:myitem, :destroy, :edit, :update]
 
+  require 'ancestry'
 
   def index
-    @ladys_items = Item.where(category_id: 159).order('created_at DESC').limit(10)
+    # 配列の用意
+    @all_ladys_items = []
+    #レディースカテゴリーの指定
+    @ladys=Category.find(1)
+    # レディースカテゴリーの子孫のカテゴリーを全て取得
+    @ladys_grandchiildren = @ladys.subtree
+    #子孫カテゴリーに該当するアイテムを全て変数に入れる
+    @ladys_grandchiildren.each do |lady|
+      @one_ladys_categoy_items = Item.where(category_id: lady.id)
+      @all_ladys_items << @one_ladys_categoy_items
+    end
+    #多次元配列を一次元にする
+    @all_ladys_items.flatten!
+    # 取り出した商品を更新日が新しい順に
+    @all_ladys_items.sort_by!{|item|item.updated_at}.reverse!
+    # 配列の最初から10個のみ表示
+    @ladys_items= @all_ladys_items.first(10)
+
+    # メンズ
+    @all_mens_items = []
+    @mens=Category.find(2)
+    @mens_grandchiildren = @mens.subtree
+    @mens_grandchiildren.each do |men|
+      @one_mens_categoy_items = Item.where(category_id: men.id)
+      @all_mens_items << @one_mens_categoy_items
+    end
+    @all_mens_items.flatten!
+    @all_mens_items.sort_by!{|item|item.updated_at}.reverse!
+    @mens_items= @all_mens_items.first(10)
+
+
+    # 家電
+    @all_electronics_items = []
+    @electronics=Category.find(8)
+    @electronics_grandchiildren = @electronics.subtree
+    @electronics_grandchiildren.each do |lady|
+      @one_electronics_categoy_items = Item.where(category_id: lady.id)
+      @all_electronics_items << @one_electronics_categoy_items
+    end
+    @all_electronics_items.flatten!
+    @all_electronics_items.sort_by!{|item|item.updated_at}.reverse!
+    @electronics_items= @all_electronics_items.first(10)
+
+    # おもちゃ
+    @all_toys_items = []
+    @toys=Category.find(6)
+    @toys_grandchiildren = @toys.subtree
+    @toys_grandchiildren.each do |lady|
+      @one_toys_categoy_items = Item.where(category_id: lady.id)
+      @all_toys_items << @one_toys_categoy_items
+    end
+    @all_toys_items.flatten!
+    @all_toys_items.sort_by!{|item|item.updated_at}.reverse!
+    @toys_items= @all_toys_items.first(10)
+
     @item_image = Item.includes(:image)
     @brands = Brand.where('name LIKE(?)', "%#{params[:keyword]}%")
     respond_to do |format|
@@ -29,7 +84,8 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path
     else
-      render :new
+      binding.pry
+      redirect_to new_item_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -56,8 +56,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path
     else
-      binding.pry
-      redirect_to new_item_path
+      render :new
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,10 +28,6 @@ class ItemsController < ApplicationController
       @items= @all_items.first(10)
       @all_category_items << @items
     end
-    @ladys_items           = @all_category_items[0]
-    @mens_items            = @all_category_items[1]
-    @toys_items            = @all_category_items[2]
-    @electronics_items     = @all_category_items[3]
 
     @item_image = Item.includes(:image)
     @brands = Brand.where('name LIKE(?)', "%#{params[:keyword]}%")

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,7 +11,7 @@ class ItemsController < ApplicationController
     # トップページのカテゴリー
     @top_catgories = Category.where(id: [1,2,6,8])
     @top_catgories.each do |category|
-      # 各カテゴリーの賞品を入れる配列の用意
+      # 各カテゴリーの商品を入れる配列の用意
       @all_items = []
       # カテゴリーの子孫のカテゴリーを全て取得
       @grandchiildren = category.subtree

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,7 +52,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path
     else
-      redirect_to new_item_path
+      render :new
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,60 +6,32 @@ class ItemsController < ApplicationController
   require 'ancestry'
 
   def index
-    # 配列の用意
-    @all_ladys_items = []
-    #レディースカテゴリーの指定
-    @ladys=Category.find(1)
-    # レディースカテゴリーの子孫のカテゴリーを全て取得
-    @ladys_grandchiildren = @ladys.subtree
-    #子孫カテゴリーに該当するアイテムを全て変数に入れる
-    @ladys_grandchiildren.each do |lady|
-      @one_ladys_categoy_items = Item.where(category_id: lady.id)
-      @all_ladys_items << @one_ladys_categoy_items
+    # トップページに表示する商品を入れるための配列
+    @all_category_items=[]
+    # トップページのカテゴリー
+    @top_catgories = Category.where(id: [1,2,6,8])
+    @top_catgories.each do |category|
+      # 各カテゴリーの賞品を入れる配列の用意
+      @all_items = []
+      # カテゴリーの子孫のカテゴリーを全て取得
+      @grandchiildren = category.subtree
+      #子孫カテゴリーに該当するアイテムを全て変数に入れる
+      @grandchiildren.each do |lady|
+        @one_categoy_items = Item.where(category_id: lady.id)
+        @all_items << @one_categoy_items
+      end
+      #[孫][孫]の様な多次元配列を一次元にする
+      @all_items.flatten!
+      # 取り出した商品を更新日が新しい順に
+      @all_items.sort_by!{|item|item.updated_at}.reverse!
+      # 配列の最初から10個のみ表示
+      @items= @all_items.first(10)
+      @all_category_items << @items
     end
-    #多次元配列を一次元にする
-    @all_ladys_items.flatten!
-    # 取り出した商品を更新日が新しい順に
-    @all_ladys_items.sort_by!{|item|item.updated_at}.reverse!
-    # 配列の最初から10個のみ表示
-    @ladys_items= @all_ladys_items.first(10)
-
-    # メンズ
-    @all_mens_items = []
-    @mens=Category.find(2)
-    @mens_grandchiildren = @mens.subtree
-    @mens_grandchiildren.each do |men|
-      @one_mens_categoy_items = Item.where(category_id: men.id)
-      @all_mens_items << @one_mens_categoy_items
-    end
-    @all_mens_items.flatten!
-    @all_mens_items.sort_by!{|item|item.updated_at}.reverse!
-    @mens_items= @all_mens_items.first(10)
-
-
-    # 家電
-    @all_electronics_items = []
-    @electronics=Category.find(8)
-    @electronics_grandchiildren = @electronics.subtree
-    @electronics_grandchiildren.each do |lady|
-      @one_electronics_categoy_items = Item.where(category_id: lady.id)
-      @all_electronics_items << @one_electronics_categoy_items
-    end
-    @all_electronics_items.flatten!
-    @all_electronics_items.sort_by!{|item|item.updated_at}.reverse!
-    @electronics_items= @all_electronics_items.first(10)
-
-    # おもちゃ
-    @all_toys_items = []
-    @toys=Category.find(6)
-    @toys_grandchiildren = @toys.subtree
-    @toys_grandchiildren.each do |lady|
-      @one_toys_categoy_items = Item.where(category_id: lady.id)
-      @all_toys_items << @one_toys_categoy_items
-    end
-    @all_toys_items.flatten!
-    @all_toys_items.sort_by!{|item|item.updated_at}.reverse!
-    @toys_items= @all_toys_items.first(10)
+    @ladys_items           = @all_category_items[0]
+    @mens_items            = @all_category_items[1]
+    @toys_items            = @all_category_items[2]
+    @electronics_items     = @all_category_items[3]
 
     @item_image = Item.includes(:image)
     @brands = Brand.where('name LIKE(?)', "%#{params[:keyword]}%")

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -11,12 +11,13 @@
           .facebook__choice.btn-default.choice-btn
             .facebook__choice__logo
               =fa_icon "facebook-square 2x"
-            .facebook__choice__text Facebookで登録する
+            .facebook__choice__text Facebookでログイン
         = link_to user_google_oauth2_omniauth_authorize_path do
           .google__choice.btn-default.choice-btn
             .google__choice__logo
               = image_tag 'google.svg', alt: 'google-logo'
-            .google__choice__text Googleで登録する
+            .google__choice__text 
+              %p Googleでログイン
     = form_with model: resource, as: resource_name, url: session_path(resource_name), id: "new_user", class: "test", local: true do |f|
       .wright__login
         .wright__login__mail__text

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,12 +1,18 @@
 = render partial: 'shared/mercari-header'
-%main.single-header
-  %section.l__single__container.buy-item-container
-    .sell__container
-      .sell__container__inner
-        %h2.l__single__head 商品の情報を入力
-        = form_with model: @item, class: "sell__form" , local: true do |f|
+= form_with model: @item, class: "sell__form" , local: true do |f|
+  %main.single-header
+    %section.l__single__container.buy-item-container
+      - if @item.errors.full_messages.any?
+        .item-form__errors
+          %h2= "#{@item.errors.full_messages.count}件のエラーが発生しました。"
+          %ul
+            - @item.errors.full_messages.each do |message|
+              %li= message
+      .sell__container
+        .sell__container__inner
+          %h2.l__single__head 商品の情報を入力
           .sell__upload__box
-            %h3.sell__upload__head{data: {item_id: @item.id}}
+            %h3.sell__upload__head
               出品画像
               %span.form__require 必須
             %p 最大10枚までアップロードできます

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -38,7 +38,7 @@
         %li.popular-category__name
           メンズ
         %li.popular-category__name
-          家電・スマホ・カメラ 
+          家電・スマホ・カメラ
         %li.popular-category__name
           おもちゃ・ホビー・グッズ
     .new-arrival-list
@@ -70,8 +70,94 @@
             .new-arrival-item__box--price
               ¥
               = item.price
-
-
+              @mens_items
+    .new-arrival-list
+      .new-arrival-list__block
+        %h3.new-arrival-item__title
+          メンズ新着アイテム
+        %p.new-arrival-item__more
+          もっと見る
+          =fa_icon"chevron-right",class:'icon'
+      .new-arrival-item
+        - @mens_items.each do |item|
+          .new-arrival-item__box
+            = link_to  item_path(item)  do
+              -if item.status == 1
+                .soldout__tag
+                  .soldout__tag__text
+                    %p SOLD
+                    .soldout__tag__back
+              -if item.item_images.present?
+                - item.item_images.each_with_index do |item_image, i|
+                  - if i == 0
+                    = image_tag item_image.image.url, alt: 'item-image', class: 'new-arrival-item__box--image'
+                  - else
+                    - break
+              - else
+                =image_tag 'no-image.png',class: 'new-arrival-item__box--image'
+            .new-arrival-item__box--text
+              = item.name
+            .new-arrival-item__box--price
+              ¥
+              = item.price
+    .new-arrival-list
+      .new-arrival-list__block
+        %h3.new-arrival-item__title
+          家電・スマホ・カメラ 新着アイテム
+        %p.new-arrival-item__more
+          もっと見る
+          =fa_icon"chevron-right",class:'icon'
+      .new-arrival-item
+        - @electronics_items.each do |item|
+          .new-arrival-item__box
+            = link_to  item_path(item)  do
+              -if item.status == 1
+                .soldout__tag
+                  .soldout__tag__text
+                    %p SOLD
+                    .soldout__tag__back
+              -if item.item_images.present?
+                - item.item_images.each_with_index do |item_image, i|
+                  - if i == 0
+                    = image_tag item_image.image.url, alt: 'item-image', class: 'new-arrival-item__box--image'
+                  - else
+                    - break
+              - else
+                =image_tag 'no-image.png',class: 'new-arrival-item__box--image'
+            .new-arrival-item__box--text
+              = item.name
+            .new-arrival-item__box--price
+              ¥
+              = item.price
+    .new-arrival-list
+      .new-arrival-list__block
+        %h3.new-arrival-item__title
+          おもちゃ・ホビー・グッズ 新着アイテム
+        %p.new-arrival-item__more
+          もっと見る
+          =fa_icon"chevron-right",class:'icon'
+      .new-arrival-item
+        - @toys_items.each do |item|
+          .new-arrival-item__box
+            = link_to  item_path(item)  do
+              -if item.status == 1
+                .soldout__tag
+                  .soldout__tag__text
+                    %p SOLD
+                    .soldout__tag__back
+              -if item.item_images.present?
+                - item.item_images.each_with_index do |item_image, i|
+                  - if i == 0
+                    = image_tag item_image.image.url, alt: 'item-image', class: 'new-arrival-item__box--image'
+                  - else
+                    - break
+              - else
+                =image_tag 'no-image.png',class: 'new-arrival-item__box--image'
+            .new-arrival-item__box--text
+              = item.name
+            .new-arrival-item__box--price
+              ¥
+              = item.price
     .popular-brands
       %h2.popular-brands__title
         人気のブランド

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -41,122 +41,43 @@
           家電・スマホ・カメラ
         %li.popular-category__name
           おもちゃ・ホビー・グッズ
-    .new-arrival-list
-      .new-arrival-list__block
-        %h3.new-arrival-item__title
-          レディース新着アイテム
-        %p.new-arrival-item__more
-          もっと見る
-          =fa_icon"chevron-right",class:'icon'
-      .new-arrival-item
-        - @ladys_items.each do |item|
-          .new-arrival-item__box
-            = link_to  item_path(item)  do
-              -if item.status == 1
-                .soldout__tag
-                  .soldout__tag__text
-                    %p SOLD
-                    .soldout__tag__back
-              -if item.item_images.present?
-                - item.item_images.each_with_index do |item_image, i|
-                  - if i == 0
-                    = image_tag item_image.image.url, alt: 'item-image', class: 'new-arrival-item__box--image'
-                  - else
-                    - break
-              - else
-                =image_tag 'no-image.png',class: 'new-arrival-item__box--image'
-            .new-arrival-item__box--text
-              = item.name
-            .new-arrival-item__box--price
-              ¥
-              = item.price
-    .new-arrival-list
-      .new-arrival-list__block
-        %h3.new-arrival-item__title
-          メンズ新着アイテム
-        %p.new-arrival-item__more
-          もっと見る
-          =fa_icon"chevron-right",class:'icon'
-      .new-arrival-item
-        - @mens_items.each do |item|
-          .new-arrival-item__box
-            = link_to  item_path(item)  do
-              -if item.status == 1
-                .soldout__tag
-                  .soldout__tag__text
-                    %p SOLD
-                    .soldout__tag__back
-              -if item.item_images.present?
-                - item.item_images.each_with_index do |item_image, i|
-                  - if i == 0
-                    = image_tag item_image.image.url, alt: 'item-image', class: 'new-arrival-item__box--image'
-                  - else
-                    - break
-              - else
-                =image_tag 'no-image.png',class: 'new-arrival-item__box--image'
-            .new-arrival-item__box--text
-              = item.name
-            .new-arrival-item__box--price
-              ¥
-              = item.price
-    .new-arrival-list
-      .new-arrival-list__block
-        %h3.new-arrival-item__title
-          家電・スマホ・カメラ 新着アイテム
-        %p.new-arrival-item__more
-          もっと見る
-          =fa_icon"chevron-right",class:'icon'
-      .new-arrival-item
-        - @electronics_items.each do |item|
-          .new-arrival-item__box
-            = link_to  item_path(item)  do
-              -if item.status == 1
-                .soldout__tag
-                  .soldout__tag__text
-                    %p SOLD
-                    .soldout__tag__back
-              -if item.item_images.present?
-                - item.item_images.each_with_index do |item_image, i|
-                  - if i == 0
-                    = image_tag item_image.image.url, alt: 'item-image', class: 'new-arrival-item__box--image'
-                  - else
-                    - break
-              - else
-                =image_tag 'no-image.png',class: 'new-arrival-item__box--image'
-            .new-arrival-item__box--text
-              = item.name
-            .new-arrival-item__box--price
-              ¥
-              = item.price
-    .new-arrival-list
-      .new-arrival-list__block
-        %h3.new-arrival-item__title
-          おもちゃ・ホビー・グッズ 新着アイテム
-        %p.new-arrival-item__more
-          もっと見る
-          =fa_icon"chevron-right",class:'icon'
-      .new-arrival-item
-        - @toys_items.each do |item|
-          .new-arrival-item__box
-            = link_to  item_path(item)  do
-              -if item.status == 1
-                .soldout__tag
-                  .soldout__tag__text
-                    %p SOLD
-                    .soldout__tag__back
-              -if item.item_images.present?
-                - item.item_images.each_with_index do |item_image, i|
-                  - if i == 0
-                    = image_tag item_image.image.url, alt: 'item-image', class: 'new-arrival-item__box--image'
-                  - else
-                    - break
-              - else
-                =image_tag 'no-image.png',class: 'new-arrival-item__box--image'
-            .new-arrival-item__box--text
-              = item.name
-            .new-arrival-item__box--price
-              ¥
-              = item.price
+    - @all_category_items.each_with_index do |items ,i|
+      .new-arrival-list
+        .new-arrival-list__block
+          %h3.new-arrival-item__title
+            - if i == 0
+              レディース新着アイテム
+            - elsif i == 1
+              メンズ新着アイテム
+            - elsif i == 2
+              家電・スマホ・カメラ 新着アイテム
+            - elsif i == 3
+              おもちゃ・ホビー・グッズ 新着アイテム
+          %p.new-arrival-item__more
+            もっと見る
+            =fa_icon"chevron-right",class:'icon'
+        .new-arrival-item
+          - items.each do |item|
+            .new-arrival-item__box
+              = link_to  item_path(item)  do
+                -if item.status == 1
+                  .soldout__tag
+                    .soldout__tag__text
+                      %p SOLD
+                      .soldout__tag__back
+                -if item.item_images.present?
+                  - item.item_images.each_with_index do |item_image, i|
+                    - if i == 0
+                      = image_tag item_image.image.url, alt: 'item-image', class: 'new-arrival-item__box--image'
+                    - else
+                      - break
+                - else
+                  =image_tag 'no-image.png',class: 'new-arrival-item__box--image'
+              .new-arrival-item__box--text
+                = item.name
+              .new-arrival-item__box--price
+                ¥
+                = item.price
     .popular-brands
       %h2.popular-brands__title
         人気のブランド

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -70,7 +70,6 @@
             .new-arrival-item__box--price
               ¥
               = item.price
-              @mens_items
     .new-arrival-list
       .new-arrival-list__block
         %h3.new-arrival-item__title

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,10 +1,16 @@
 = render partial: 'shared/mercari-header'
-%main.single-header
-  %section.l__single__container.buy-item-container
-    .sell__container
-      .sell__container__inner
-        %h2.l__single__head 商品の情報を入力
-        = form_with model: @item, class: "sell__form" , local: true do |f|
+= form_with model: @item, class: "sell__form" , local: true do |f|
+  %main.single-header
+    %section.l__single__container.buy-item-container
+      - if @item.errors.full_messages.any?
+        .item-form__errors
+          %h2= "#{@item.errors.full_messages.count}件のエラーが発生しました。"
+          %ul
+            - @item.errors.full_messages.each do |message|
+              %li= message
+      .sell__container
+        .sell__container__inner
+          %h2.l__single__head 商品の情報を入力
           .sell__upload__box
             %h3.sell__upload__head
               出品画像

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module FreemarketSample53b
   class Application < Rails::Application
     config.action_view.automatically_disable_submit_tag = false
     config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.generators do |g|

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,4 @@
 ja:
-  recaptcha: 
-    errors: 
-      verification_failed: 'reCAPTCHA認証に失敗しました。' 
+  recaptcha:
+    errors:
+      verification_failed: 'reCAPTCHA認証に失敗しました。'

--- a/config/locales/model/ja.yml
+++ b/config/locales/model/ja.yml
@@ -1,0 +1,15 @@
+ja:
+  activerecord:
+    models:
+      item: 商品
+    attributes:
+      item:
+        name: 商品名
+        description: 商品の説明
+        price: 価格
+        region: 配送元の地域
+        delivery_fee: 配送料の負担
+        delivery_days: 配送までの日数
+        shipping_method: 配送方法
+        brand: ブランド
+        category: カテゴリー


### PR DESCRIPTION
# what
・トップページにレディースのサングラスのカテゴリーの商品が表示されるのを
レディース、メンズ、おもちゃ、家電の孫カテゴリーのもの全てから
更新日が新しい順で10個づつ各カテゴリーで表示される様に変更。

・商品出品のエラー時にアドレスバーがnewにならず登録できなかったのを修正

・商品登録、編集時にエラーが起きるとエラー文を表示する機能の実装

・ログイン画面のビューの修正（文字の変更と変更によりずれた部分の微調整）

[![Image from Gyazo](https://i.gyazo.com/ece93713331b6dc72d78321d965171b5.gif)](https://gyazo.com/ece93713331b6dc72d78321d965171b5)

[![Image from Gyazo](https://i.gyazo.com/fc6ba0dea108d19c9078bc49de65caeb.png)](https://gyazo.com/fc6ba0dea108d19c9078bc49de65caeb)